### PR TITLE
docker should no longer have issues with windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+container-entrypoint.sh text eol=lf


### PR DESCRIPTION
=> container-entrypoint.sh should now commit/pull with LF rather than CRLF, avoiding a silly bug with docker being unable to find the file for some reason