### PR TITLE
Make superuser creation on container start idempotent

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -27,8 +27,21 @@ python manage.py collectstatic --noinput --clear
 if [ -z "$DJANGO_SUPERUSER_USERNAME" ] || [ -z "$DJANGO_SUPERUSER_PASSWORD" ] ; then
     echo "Superuser credentials not provided, skipping superuser creation."
 else
-    echo "Creating superuser $DJANGO_SUPERUSER_USERNAME"
-    echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$DJANGO_SUPERUSER_USERNAME', '$DJANGO_SUPERUSER_EMAIL', '$DJANGO_SUPERUSER_PASSWORD')" | python manage.py shell
+    echo "Ensuring superuser $DJANGO_SUPERUSER_USERNAME exists"
+    python manage.py shell << EOF
+from django.contrib.auth import get_user_model
+User = get_user_model()
+
+username = "$DJANGO_SUPERUSER_USERNAME"
+email = "$DJANGO_SUPERUSER_EMAIL"
+password = "$DJANGO_SUPERUSER_PASSWORD"
+
+if not User.objects.filter(username=username).exists():
+    User.objects.create_superuser(username, email, password)
+    print("Superuser created:", username)
+else:
+    print("Superuser already exists:", username)
+EOF
 fi
 
 # Start server


### PR DESCRIPTION
- Moved the single line unreadable python script into a multiline one.
- Made the superuser creation idemponent, so the container doesn't crash on restart.
- I haven't tested the code - just wrote it out quickly for a PR.