### PR TITLE
Fix language selection bug

### DIFF
--- a/hot_osm/settings/base.py
+++ b/hot_osm/settings/base.py
@@ -90,7 +90,6 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -98,6 +97,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 
@@ -117,6 +117,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.i18n",
                 "wagtail.contrib.settings.context_processors.settings",
             ],
         },

--- a/utils/templates/language_switcher.html
+++ b/utils/templates/language_switcher.html
@@ -1,26 +1,30 @@
 {% load i18n %}
 {% load util_filters %}
-{% get_current_language as LANGUAGE_CODE %} {# Fetches the current language code, e.g., "en" #}
+{% load wagtailcore_tags %}
+
+{% get_current_language as LANGUAGE_CODE %}
+
 <div x-data="{language: '{{ LANGUAGE_CODE }}'}">
-    <form action="{% url "set_language" %}" method="post">
-        {% csrf_token %}
-        <input name="next" type="hidden" value="{{ redirect_to }}" class="text-small">
-        <!-- The select element with custom styling for language selection -->
-        <select name="language"
-                aria-label="Language Select"
-                x-model="language"
-                @change="$event.target.form.submit()"
-                arial-labelledby="language-select-label"
-                class="language-select hover:underline border-none appearance-none focus:outline-none pl-4 cursor-pointer lg:pl-0 text-small">
-            {% get_available_languages as LANGUAGES %} {# Fetches a list of available languages as tuples, e.g., ("en", "English") #}
-            {% get_language_info_list for LANGUAGES as languages %}
-            {% for language in languages %}
-                <!-- Option elements for each available language -->
-                <option value="{{ language.code }}"
-                        {% if language.code == LANGUAGE_CODE %}selected{% endif %}>
-                    {{ language.name_local|title_case }}
-                </option>
-            {% endfor %}
-        </select>
-    </form>
+  <select
+    name="language"
+    aria-label="Language Select"
+    x-model="language"
+    @change="window.location = ($event.target.options[$event.target.selectedIndex].dataset.url)"
+    arial-labelledby="language-select-label"
+    class="language-select hover:underline border-none appearance-none focus:outline-none pl-4 cursor-pointer lg:pl-0 text-small"
+  >
+    {% get_available_languages as LANGUAGES %}
+    {% get_language_info_list for LANGUAGES as languages %}
+    {% for language in languages %}
+      {% language language.code %}
+        <option
+          value="{{ language.code }}"
+          data-url="{% pageurl page.localized %}"
+          {% if language.code == LANGUAGE_CODE %}selected{% endif %}
+        >
+          {{ language.name_local|title_case }}
+        </option>
+      {% endlanguage %}
+    {% endfor %}
+  </select>
 </div>


### PR DESCRIPTION
## What was the issue?

The website used django's `set_language` view that set's the user's preferred language, but that is not aware of wagtail content and its translations. While the bug says "for some pages", I found none in which it worked, and as per the django docs, and wagtail docs, it does not make any sense that it ever worked.

## What is the solution

Use wagtail's own language switching [as documented](https://docs.wagtail.org/en/v6.2.4/advanced_topics/i18n.html#language-region-selector). The proposed technique uses links to the translated content. I tweaked it to keep the current UI with the selector.