### PR TITLE
use internationalized path to the search page

### DIFF
--- a/app/ui/templates/ui/components/navigation/SearchForm.html
+++ b/app/ui/templates/ui/components/navigation/SearchForm.html
@@ -3,20 +3,24 @@
 - has_ref: optional; if Truthy, this will have an x-ref
     - means that this form can be focused via alpinejs; if multiple have this ref it obviously won't work for all of them
 {% endcomment %}
-<form class="w-full flex items-center" action="/search">
-    <button class="px-4 py-2" aria-label="Search form submit button">
-        {% include "ui/components/icon_svgs/SearchIcon.html" with class="text-gray-400" %}
-    </button>
-    <input type="text"
-            id="keyword"
-            name="keyword"
-            class="w-full border-0 bg-transparent text-gray-900 placeholder:text-gray-400 focus:ring-0"
-            {% if has_ref %}
-                x-ref="searchforminput"
-            {% endif %}
-            @input="makeLiveSearch($event.target.value); searchkeyword = $event.target.value;"
-            placeholder="Search"
-            role="combobox"
-            aria-expanded="false"
-            aria-controls="options">
+{% load homepage_tags %}
+
+{% get_search_page as search_page %}
+
+<form class="w-full flex items-center" action="{{ search_page.url }}" method="GET">
+  <button class="px-4 py-2" aria-label="Search form submit button">
+    {% include "ui/components/icon_svgs/SearchIcon.html" with class="text-gray-400" %}
+  </button>
+
+  <input
+    type="text"
+    id="keyword"
+    name="keyword"
+    class="w-full border-0 bg-transparent text-gray-900 placeholder:text-gray-400 focus:ring-0"
+    placeholder="Search"
+    role="combobox"
+    aria-expanded="false"
+    aria-controls="options"
+    value="{{ keyword }}"
+  />
 </form>

--- a/home/templatetags/homepage_tags.py
+++ b/home/templatetags/homepage_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from home.models import HomePage
+from app.search_page.models import SearchPage
 from django.conf import settings
 
 register = template.Library()
@@ -17,6 +18,11 @@ def get_home_page(context):
         home_page = HomePage.objects.live().filter(locale=context['page'].locale).first().specific
 
     return home_page
+
+
+@register.simple_tag(takes_context=True)
+def get_search_page(context):
+    return SearchPage.objects.live().filter(locale=context['page'].locale).first().specific
 
 
 @register.simple_tag(takes_context=True)

--- a/hot_osm/urls.py
+++ b/hot_osm/urls.py
@@ -8,8 +8,6 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
-# from search import views as search_views
-
 
 def lbheartbeat(_request):
     return HttpResponse("ok", content_type="text/plain")
@@ -43,7 +41,6 @@ urlpatterns.extend(
         # Wagtail's page serving mechanism. This should be the last pattern in
         # the list:
         path("", include(wagtail_urls)),
-        # path("search/", search_views.search, name="search"),
         # Alternatively, if you want Wagtail pages to be served from a subpath
         # of your site, rather than the site root:
         #    path("pages/", include(wagtail_urls)),


### PR DESCRIPTION
## What was the issue

Search functionality was mostly implemented (although in a quite strange place) but lacked a proper routing mechanism: The hardcoded url for search does not exist and it does not consider current language.

## How was it fixed

A mechanism to find the current locale's search page was implemented. This is used to get the url for the search form.

## Further work

It is necessary to go into the database and delete from the `wagtailredirects_redirect` table all possible redirects that exist for urls related to search. This was found to further interfere with search functionality.