### PR TITLE
consider locale when searching for related news

### DIFF
--- a/app/news/models.py
+++ b/app/news/models.py
@@ -29,7 +29,7 @@ class NewsOwnerPage(Page):
 
     #     keyword = request.GET.get('keyword', '')
     #     news_list = IndividualNewsPage.objects.live().filter(locale=base_locale)
-        
+
     #     if keyword:
     #         news_list = news_list.search(keyword).get_queryset()
 
@@ -40,7 +40,7 @@ class NewsOwnerPage(Page):
     #         if request.GET.get("cat" + str(category.id), ''):
     #             query = query | Q(categories=category)
     #     news_list = news_list.filter(query).distinct()
-        
+
     #     query = Q()
     #     for tag in tags:
     #         query = query | Q(tags__name=tag)
@@ -73,7 +73,7 @@ class NewsOwnerPage(Page):
     #         news = paginator.page(1)
     #     except EmptyPage:
     #         news = paginator.page(paginator.num_pages)
-        
+
     #     context['news'] = news
     #     context['news_paginator'] = paginator
     #     context['current_page'] = int(page)
@@ -87,7 +87,7 @@ class NewsOwnerPage(Page):
         base_locale = context['page'].get_translation(1).locale
 
         keyword = request.GET.get('keyword', '')
-        
+
         # SOLUTION 2: Optimize queries (removed associated_hubs from prefetch_related)
         news_list = IndividualNewsPage.objects.live().filter(
             locale=base_locale
@@ -98,7 +98,7 @@ class NewsOwnerPage(Page):
             'tags'          # Fetch all tags in one query
             # Note: associated_hubs removed because it's a StreamField
         )
-        
+
         if keyword:
             news_list = news_list.search(keyword).get_queryset()
 
@@ -109,7 +109,7 @@ class NewsOwnerPage(Page):
             if request.GET.get("cat" + str(category.id), ''):
                 query = query | Q(categories=category)
         news_list = news_list.filter(query).distinct()
-        
+
         query = Q()
         for tag in tags:
             query = query | Q(tags__name=tag)
@@ -124,7 +124,7 @@ class NewsOwnerPage(Page):
 
         # SOLUTION 2: Add safety measures for sorting with limits
         total_count = news_list.count()
-        
+
         match request.GET.get('sort', ''):
             case 'sort.new':
                 news_list = news_list.order_by('-date')
@@ -153,14 +153,14 @@ class NewsOwnerPage(Page):
             news = paginator.page(1)
         except EmptyPage:
             news = paginator.page(paginator.num_pages)
-        
+
         context['news'] = news
         context['news_paginator'] = paginator
         context['current_page'] = int(page)
         context['categories'] = categories
         context['hubs'] = hubs
         return context
-    
+
     max_count = 1
 
     subpage_types = [
@@ -245,7 +245,7 @@ class NewsCategory(models.Model):
 
     def __str__(self):
         return self.category_name
-    
+
     class Meta:
         verbose_name_plural = "News Categories"
 
@@ -325,30 +325,30 @@ class IndividualNewsPage(Page):
     ]
 
     @classmethod
-    def get_tool_related_news(cls, tool_name=None, tool_tags=None, limit=6):
+    def get_tool_related_news(cls, locale, tool_name=None, tool_tags=None, limit=6):
         """
         Get news articles related to a specific tool
         """
         from django.db.models import Q
-        
-        news_queryset = cls.objects.live().order_by('-date')
-        
+
+        news_queryset = cls.objects.live().order_by('-date').filter(locale=locale)
+
         if tool_name or tool_tags:
             query = Q()
-            
+
             if tool_name:
                 query |= Q(title__icontains=tool_name)
-            
+
             if tool_tags:
                 for tag in tool_tags:
                     query |= Q(tags__name__icontains=tag)
-            
+
             if query:
-                news_queryset = news_queryset.filter(query).distinct()
-        
+                news_queryset = news_queryset.filter(query)
+
+        news_queryset = news_queryset.distinct()
+
         if limit:
             news_queryset = news_queryset[:limit]
-        
-        return news_queryset
 
-    
+        return news_queryset

--- a/app/tech/models.py
+++ b/app/tech/models.py
@@ -68,26 +68,31 @@ class IndividualTechStackPage(Page):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
-        
+
         from app.news.models import IndividualNewsPage
-        
+
         if self.slug == 'drone-tasking-manager':
             # Get DroneTM-specific news
             tool_news = IndividualNewsPage.get_tool_related_news(
+                locale=context['page'].locale,
                 tool_name='DroneTM',
                 tool_tags=['dronetm', 'drone', 'drone mapping'],
                 limit=6
             )
             section_title = 'DroneTM News'
         else:
-            tool_news = IndividualNewsPage.get_tool_related_news(limit=3)
+            tool_news = IndividualNewsPage.get_tool_related_news(
+                locale=context['page'].locale,
+                limit=3,
+            )
+
             section_title = 'Recent News'
-        
+
         context.update({
             'tool_news': tool_news,
             'news_section_title': section_title,
         })
-        
+
         return context
 
 
@@ -170,7 +175,7 @@ class TechProductSuitePage(Page):
                 FieldPanel('tech_stack_cta_title'),
                 FieldPanel('tech_stack_cta_description'),
                 FieldPanel('tech_stack_cta_button_link_text'),
-                FieldPanel('tech_stack_cta_button_link_url'),    
+                FieldPanel('tech_stack_cta_button_link_url'),
             ], heading="Call to Action"),
             FieldPanel('tech_stack_go_back_text'),
         ], heading="Individual Tech Stack Page"),

--- a/app/tech/templates/tech/individual_tech_stack_page.html
+++ b/app/tech/templates/tech/individual_tech_stack_page.html
@@ -11,7 +11,7 @@
 
 {% block content %}
     {% include "ui/components/PageHeaderWithBlur.html" with title=page.title image=page.header_image endinlarge=True full_length=True smaller=True %}
-    
+
     <div class="max-w-7xl mx-auto my-10">
         <div class="px-6 md:px-10">
             <div class="max-w-5xl mb-10 col-span-5">
@@ -69,12 +69,10 @@
                 {% endfor %}
             </div>
 
-            {% comment %} news section {% endcomment %}
             <div class="my-20">
-                 {% include "ui/components/news/NewsToolSection.html" with news_articles=tool_news section_title=news_section_title %}
+              {% include "ui/components/news/NewsToolSection.html" with news_articles=tool_news section_title=news_section_title %}
             </div>
-            
-            
+
             {% include "ui/components/FooterBannerWithTextAndLink.html" with text=page.get_parent.specific.tech_stack_cta_title description=page.get_parent.specific.tech_stack_cta_description buttontext=page.get_parent.specific.tech_stack_cta_button_link_text url=page.get_parent.specific.tech_stack_cta_button_link_url %}
 
             <p class="my-20 text-intro">

--- a/app/tech/templates/tech/tech_product_suite_page.html
+++ b/app/tech/templates/tech/tech_product_suite_page.html
@@ -11,7 +11,7 @@
 
 {% block content %}
     {% include "ui/components/PageHeaderWithBlur.html" with title=page.title image=page.header_image endinlarge=True full_length=True smaller=True %}
-    
+
     <div class="max-w-7xl mx-auto my-10">
         <div class="px-6 md:px-10">
             <div class="lg:grid lg:grid-cols-6 mb-20">


### PR DESCRIPTION
fixes issue #51 

## what was happening

search for related articles did not take locale into account. Thust it returned the same article in three different locales. Although tecnically a differente article is a characteristic of wagtail that a version of a page in a language can be initially identical to the original version. This happens with the cited page and the related news in the issue. How unfortunate.

## how was it fixed

search for related news now takes current locale into account, therefore it cannot happen that the same article appears for every locale.