### PR TITLE
Fix language switcher preventing redirects

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 icon: https://hotosm.org/static/images/favicon-16x16.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: "1.0.6"
+appVersion: "1.0.7"
 
 dependencies:
   - name: dragonfly

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/hotosm/website
-  tag: "6d1d8feedc00b5801ff6dd687646891d4a24e035" 
+  tag: main 
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/utils/templates/language_switcher.html
+++ b/utils/templates/language_switcher.html
@@ -19,7 +19,7 @@
       {% language language.code %}
         <option
           value="{{ language.code }}"
-          data-url="{% pageurl page.localized %}"
+          data-url="{% if page %}{% pageurl page.localized %}{% else %}/{{ language.code }}/{% endif %}"
           {% if language.code == LANGUAGE_CODE %}selected{% endif %}
         >
           {{ language.name_local|title_case }}


### PR DESCRIPTION
With pages that don't actually exists (such as the home page, which requires a redirect), the language switcher checks for a valid page after the page is detected to exists by Django. This fix will check if we need to add the `/en/` first before it fails. 