### PR TITLE
fix(urls): redirect bare /admin to /admin/ before locale prefix

### DIFF
--- a/hot_osm/urls.py
+++ b/hot_osm/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
+from django.views.generic import RedirectView
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
@@ -19,6 +20,8 @@ urlpatterns = [
     path("__lbheartbeat__", lbheartbeat),
     path("i18n/", include("django.conf.urls.i18n")),
     path("django-admin/", admin.site.urls),
+    # Avoid locale-prefixed slash redirect (/admin → /es/admin/) which 404s.
+    path("admin", RedirectView.as_view(url="/admin/", permanent=True)),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
     path("__reload__/", include("django_browser_reload.urls")),


### PR DESCRIPTION
## Summary
- Adds a non-i18n redirect from `/admin` to `/admin/` before Django's locale-aware slash redirect runs
- Prevents Chrome users from being sent to `/es/admin/` (404) when typing `hotosm.org/admin`

Fixes #97

## Root cause
Wagtail admin is mounted at `/admin/` outside `i18n_patterns`. When users omit the trailing slash, `CommonMiddleware` redirects with a locale prefix (`/es/admin/`), which hits Wagtail page routing instead of the admin app.

## Test plan
- [ ] Visit `https://www.hotosm.org/admin` in Chrome with Spanish `Accept-Language` → should land on admin login
- [ ] Visit `/admin/` directly → still works
- [ ] Locale-prefixed public pages (`/es/...`) unaffected

Made with [Cursor](https://cursor.com)