### PR TITLE
fix(migration): set wagtail Image description on programmatic create

### DIFF
--- a/home/management/migration_helpers.py
+++ b/home/management/migration_helpers.py
@@ -18,7 +18,8 @@ def create_image_from_bytes(image_bytes: bytes, image_name: str, image_title: st
     img_file = ImageFile(BytesIO(image_bytes), name=image_name)
 
     image = Image(
-        title=image_name,
+        title=image_title,
+        description=image_title,
         file=img_file,
     )
     image.save()


### PR DESCRIPTION
## Summary
- Sets `description` (and uses `image_title` for `title`) when creating Wagtail images in migration helpers
- Prevents `IntegrityError: null value in column "description"` on programmatic image uploads

Fixes #92

## Test plan
- [ ] Run `create_image_from_bytes()` in a shell — image saves without IntegrityError
- [ ] Upload image via Wagtail admin — still works (unaffected)

Made with [Cursor](https://cursor.com)