### PR TITLE
fix(nav): make dropdown parent items non-clickable

### DIFF
--- a/app/ui/templates/ui/components/navigation/HeaderNavbarItem.html
+++ b/app/ui/templates/ui/components/navigation/HeaderNavbarItem.html
@@ -5,12 +5,12 @@
 {% endcomment %}
 <div class="text-small font-medium [&>.show-at-large]:hidden [&:hover>.show-at-large]:block p-2 [&>p]:hover:text-hot-red [&_p:hover]:text-hot-red text-left">
     <p class="">
-        {%if item.link%}
+        {%if item.link and not item.children%}
             <a href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=item.link%}">
                 <span class="{%if item.children%}pr-2{%endif%}">{{item.title}}</span>
             </a>
-            {% else %}
-            <span class="{%if item.children%}pr-2{%endif%}">{{item.title}}</span>
+        {% else %}
+            <span class="{%if item.children%}pr-2 cursor-default{%endif%}">{{item.title}}</span>
         {%endif%}
         {% if item.children %}
             {% include "ui/components/icon_svgs/LinkCaret.html" with class="rotate-90 text-hot-red" %}
@@ -23,9 +23,13 @@
             {% for child in item.children %}
                 <div class="[&>.show-at-large]:hidden [&:hover>.show-at-large]:block px-6 py-2">
                     <p class="">
-                        <a class="hover:text-hot-red" href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=child.value.link%}">
-                            {{child.value.title}}
-                        </a>
+                        {% if child.value.link and not child.value.children %}
+                            <a class="hover:text-hot-red" href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=child.value.link%}">
+                                {{child.value.title}}
+                            </a>
+                        {% else %}
+                            <span class="{% if child.value.children %}cursor-default{% endif %}">{{child.value.title}}</span>
+                        {% endif %}
                         {% if child.value.children %}
                             {% include "ui/components/icon_svgs/LinkCaret.html" with class="text-hot-red caret-arrow ml-2 rotate-90 lg:rotate-0" %}
                         {% endif %}

--- a/app/ui/templates/ui/components/navigation/HeaderNavbarItemMobile.html
+++ b/app/ui/templates/ui/components/navigation/HeaderNavbarItemMobile.html
@@ -4,10 +4,14 @@
     - these children will have the same parameters, and those children's children will have the same except they cannot have children
 {% endcomment %}
 <div x-data="{ opened: false }" class="text-small font-medium p-2 [&>p]:hover:text-hot-red [&_p:hover]:text-hot-red text-left">
-    <p class="cursor-pointer" @click="opened = !opened">
-        <a href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=item.link%}">
-            <span class="{%if item.children%}pr-2{%endif%}">{{item.title}}</span>
-        </a>
+    <p class="{% if item.children %}cursor-default{% else %}cursor-pointer{% endif %}" {% if item.children %}@click="opened = !opened"{% endif %}>
+        {% if item.link and not item.children %}
+            <a href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=item.link%}">
+                <span class="{%if item.children%}pr-2{%endif%}">{{item.title}}</span>
+            </a>
+        {% else %}
+            <span class="{%if item.children%}pr-2{%endif%}" {% if item.children %}@click="opened = !opened"{% endif %}>{{item.title}}</span>
+        {% endif %}
         {% if item.children %}
             {% include "ui/components/icon_svgs/LinkCaret.html" with class="rotate-90 text-hot-red" %}
         {% endif %}
@@ -18,10 +22,14 @@
             {% comment %} CHILDREN NAVBAR ITEMS {% endcomment %}
             {% for child in item.children %}
                 <div class="px-6 py-2" x-data="{ gcOpened: false }">
-                    <p class="cursor-pointer" @click="gcOpened = !gcOpened">
-                        <a class="hover:text-hot-red" href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=child.value.link%}">
-                            {{child.value.title}}
-                        </a>
+                    <p class="{% if child.value.children %}cursor-default{% else %}cursor-pointer{% endif %}" {% if child.value.children %}@click="gcOpened = !gcOpened"{% endif %}>
+                        {% if child.value.link and not child.value.children %}
+                            <a class="hover:text-hot-red" href="{%include 'ui/components/PageOrLinkHrefText.html' with linkurl=child.value.link%}">
+                                {{child.value.title}}
+                            </a>
+                        {% else %}
+                            <span {% if child.value.children %}@click="gcOpened = !gcOpened"{% endif %}>{{child.value.title}}</span>
+                        {% endif %}
                         {% if child.value.children %}
                             {% include "ui/components/icon_svgs/LinkCaret.html" with class="text-hot-red caret-arrow ml-2 rotate-90 lg:rotate-0" %}
                         {% endif %}


### PR DESCRIPTION
## Summary
- Desktop and mobile nav templates skip the `<a>` tag when a nav item has children
- Parent items with dropdowns (e.g. "Our People") show hover/expand only — no dead link

Fixes #54

## Test plan
- [ ] Hover "Our People" on desktop — dropdown opens, parent is not a link
- [ ] Tap "Our People" on mobile — submenu toggles, no navigation to empty/broken URL
- [ ] Leaf nav items (no children) still link normally

Made with [Cursor](https://cursor.com)