### PR TITLE
fix(news): render MarkdownField intro with markdown filter

### DIFF
--- a/app/news/templates/news/individual_news_page.html
+++ b/app/news/templates/news/individual_news_page.html
@@ -39,7 +39,7 @@
                         </div>
 
                         <div class="text-intro">
-                            {{ page.intro|richtext }}
+                            {{ page.intro|markdown }}
                         </div>
                         {{ page.article_body }}
                     </div>

--- a/app/ui/templates/ui/components/news/NewsPreviewBlockNews.html
+++ b/app/ui/templates/ui/components/news/NewsPreviewBlockNews.html
@@ -4,6 +4,7 @@
 - readmoretext: a string; the text that should show for the "read more" button
 {% endcomment %}
 {% load wagtailcore_tags %}
+{% load wagtailmarkdown %}
 
 {% with news.localized as news %}
     <div class="{{class}}">
@@ -18,7 +19,7 @@
         </p>
 
         <div class="max-h-20 text-ellipsis overflow-hidden text-small">
-            {{ news.intro|richtext }}
+            {{ news.intro|markdown }}
         </div>
 
         <p class="mt-4 font-medium">

--- a/app/ui/templates/ui/components/news/NewsPreviewBlockProjects.html
+++ b/app/ui/templates/ui/components/news/NewsPreviewBlockProjects.html
@@ -5,6 +5,7 @@
 {% endcomment %}
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
+{% load wagtailmarkdown %}
 
 {% with news.localized as news %}
     {% if news.image %}
@@ -34,7 +35,7 @@
             </p>
 
             <div class="max-h-20 text-ellipsis overflow-hidden text-small">
-                {{ news.intro|richtext }}
+                {{ news.intro|markdown }}
             </div>
 
             <p class="my-2">


### PR DESCRIPTION
## Summary
- Renders news page intro with `|markdown` instead of `|richtext` (intro is a `MarkdownField`)
- Updates news preview components to use the same filter

Fixes #63

## Root cause
`IndividualNewsPage.intro` is a `MarkdownField`, but templates used the Wagtail richtext filter, which does not process markdown/HTML embeds correctly — especially custom `<style>` blocks and Tailwind classes allowed by `WAGTAILMARKDOWN`.

## Test plan
- [ ] Open a news page with embedded `<style>` or Tailwind classes in intro — styling renders on prod
- [ ] News preview blocks on listing pages show intro text correctly

Made with [Cursor](https://cursor.com)