### PR TITLE
feat(members): add Other option to region hub filter

### DIFF
--- a/app/members/migrations/0023_membergroupownerpage_filter_other_label.py
+++ b/app/members/migrations/0023_membergroupownerpage_filter_other_label.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("members", "0022_remove_individualmemberpage_intro"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="membergroupownerpage",
+            name="filter_other_label",
+            field=models.CharField(
+                default="Other",
+                help_text="Label for members not assigned to any mapping hub region.",
+            ),
+        ),
+    ]

--- a/app/members/models.py
+++ b/app/members/models.py
@@ -33,6 +33,7 @@ class MemberGroupOwnerPage(Page):
     applied_text = models.CharField(default="applied", help_text="This will be a suffix to a number, used to indicate how many filters are applied currently in some field.")
     search_placeholder = models.CharField(default="Search by name")
     filter_by_country = models.CharField(default="Filter by Country")
+    filter_other_label = models.CharField(default="Other", help_text="Label for members not assigned to any mapping hub region.")
     sort_by_titlea = models.CharField(default="Sort by Name Alphabetical")
     sort_by_titlez = models.CharField(default="Sort by Name Reverse Alphabetical")
     search_button_text = models.CharField(default="Search")
@@ -52,6 +53,7 @@ class MemberGroupOwnerPage(Page):
             FieldPanel('applied_text'),
             FieldPanel('search_placeholder'),
             FieldPanel('filter_by_country'),
+            FieldPanel('filter_other_label'),
             FieldPanel('sort_by_titlea'),
             FieldPanel('sort_by_titlez'),
             FieldPanel('search_button_text'),
@@ -84,10 +86,16 @@ class MemberGroupPage(Page):
         
         hubs = IndividualMappingHubPage.objects.live().filter(locale=context['page'].get_translation(1).locale)
         query = Q()
+        hub_filters_active = False
         for hub in hubs:
             if request.GET.get("hub" + str(hub.id), ''):
                 query = query | Q(location_hub=hub)
-        members = members.filter(query).distinct()
+                hub_filters_active = True
+        if request.GET.get("hubother", ''):
+            query = query | Q(location_hub__isnull=True)
+            hub_filters_active = True
+        if hub_filters_active:
+            members = members.filter(query).distinct()
 
         match request.GET.get('sort', ''):
             case 'sort.titlea':

--- a/app/members/templates/members/member_group_page.html
+++ b/app/members/templates/members/member_group_page.html
@@ -72,6 +72,10 @@
                                     <input class="ml-auto checked:bg-hot-red checked:hover:bg-hot-red checked:focus:bg-hot-red" id="hub-{{forloop.counter}}" type="checkbox" name="hub{{hub.id}}" :checked="params.get('hub{{hub.id}}')">
                                 </div>
                             {% endfor %}
+                            <div class="mt-4 flex">
+                                <label for="hub-other">{{page.get_parent.specific.filter_other_label}}</label>
+                                <input class="ml-auto checked:bg-hot-red checked:hover:bg-hot-red checked:focus:bg-hot-red" id="hub-other" type="checkbox" name="hubother" :checked="params.get('hubother')">
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Adds an "Other" checkbox to the member region filter for people not assigned to a mapping hub
- Only applies hub filters when at least one region option is selected (fixes empty-filter edge case)

Fixes #84

## Test plan
- [ ] Open a member group page with search options enabled
- [ ] Select "Other" only — members with no `location_hub` appear
- [ ] Combine "Other" with a hub filter — union of both sets shown

Made with [Cursor](https://cursor.com)