### PR TITLE
chore: replace black/isort/flake8 pre-commit with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,20 +6,12 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
     hooks:
-      - id: black
-        language_version: python3.12
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
   - repo: https://github.com/Riverside-Healthcare/djLint
     rev: v1.32.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ license = {text = "AGPL-3.0-only"}
 [dependency-groups]
 dev = [
     "pre-commit==3.5.0",
+    "ruff==0.9.10",
     "pytest-django==4.7.0",
     "pytest-timeout==2.2.0",
     "pytest-factoryboy==2.6.0",
@@ -46,18 +47,17 @@ dev = [
     "django-pattern-library==1.5.0",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 100
-target-version = ['py312']
-include = '\.pyi?$'
+target-version = "py311"
+exclude = ["*/migrations/*"]
 
-[tool.isort]
-profile = "django"
-combine_as_imports = true
-include_trailing_comma = true
-line_length = 100
-multi_line_output = 3
-known_first_party = ["config"]
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["hot_osm", "home", "app", "users", "utils"]
 
 [tool.djlint]
 profile = "django"


### PR DESCRIPTION
## Summary
- Replaces black, isort, and flake8 pre-commit hooks with ruff + ruff-format
- Adds `[tool.ruff]` config to `pyproject.toml` (line-length 100, isort, common rules)
- Adds `ruff` to dev dependency group

Fixes #82

## Test plan
- [ ] `pre-commit run --all-files` passes (or reports only pre-existing issues)
- [ ] CI test stage still passes

Made with [Cursor](https://cursor.com)